### PR TITLE
Bugfix/FIND-12336 fix flakey tests

### DIFF
--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/BoolFilterTest.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/BoolFilterTest.cs
@@ -18,7 +18,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content3", NameSearchable = "Not exists priority", Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE, StartPublish = DateTime.Parse("2022-10-13T17:17:56Z", null, System.Globalization.DateTimeStyles.AdjustToUniversal) });
             var item4 = TestDataCreator.generateIndexActionJson("4", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content4", NameSearchable = "Home 4", Status = TestDataCreator.STATUS_PUBLISHED, Priority = 300, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE, StartPublish = DateTime.Parse("2022-10-14T17:17:56Z", null, System.Globalization.DateTimeStyles.AdjustToUniversal) });
 
-            SetupData<HomePage>(item1 + item2 + item3 + item4);
+            SetupData<HomePage>(item1 + item2 + item3 + item4, "t1");
         }
         #region And filter
         [TestMethod]

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/ComplexQueriesTest.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/ComplexQueriesTest.cs
@@ -27,7 +27,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
                 MainBodySearchable = "Semantic search is supported on searchable string fields, and for the full-text search operators contains and match. It is recommended to set fields that have a lot of content (such as the MainBody in the Optimizely CMS) as searchable to unlock the full-text search capabilities. Optimizely Graph uses a pre-trained model for semantic search.",
                 Priority = 0, IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<HomePage>(item1 + item2 + item3);
+            SetupData<HomePage>(item1 + item2 + item3, "t2");
         }
 
         [TestCategory("Subtype test")]

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/FacetsTest.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/FacetsTest.cs
@@ -18,7 +18,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content3", NameSearchable = "Not exists priority", IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item4 = TestDataCreator.generateIndexActionJson("4", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content4", NameSearchable = "Home 4", Priority = 300, IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<HomePage>(item1 + item2 + item3 + item4);
+            SetupData<HomePage>(item1 + item2 + item3 + item4, "t3");
         }
         [TestMethod]
         public void search_with_string_facet_should_return_2_facets()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/FilterForVisitorTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/FilterForVisitorTests.cs
@@ -21,7 +21,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { 
                 ContentType = new[] { "Content" }, Id = "content3", NameSearchable = "Alan Turing", Author = "manv", Status = TestDataCreator.STATUS_DELETED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<Content>(item1 + item2 + item3);
+            SetupData<Content>(item1 + item2 + item3, "t4");
         }
         [TestMethod]
         public void search_without_filter_for_visitors_should_result_3_items()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/FragmentTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/FragmentTests.cs
@@ -16,7 +16,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content3", NameSearchable = "Home 3", IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item4 = TestDataCreator.generateIndexActionJson("4", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content4", NameSearchable = "Home 4", Priority = 300, IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<HomePage>(item1 + item2 + item3 + item4);
+            SetupData<HomePage>(item1 + item2 + item3 + item4, "t5");
         }
         [TestMethod]
         public void select_2_fields_in_fragment_should_return_2_fields_in_result()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/LimitTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/LimitTests.cs
@@ -17,7 +17,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content3", NameSearchable = "Not exists priority", IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item4 = TestDataCreator.generateIndexActionJson("4", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content4", NameSearchable = "Home 4", Priority = 300, IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<HomePage>(item1 + item2 + item3 + item4);
+            SetupData<HomePage>(item1 + item2 + item3 + item4, "t6");
         }
         [TestMethod]
         public void search_with_limit_1_should_return_1_hit()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/LocaleTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/LocaleTests.cs
@@ -15,7 +15,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item2 = TestDataCreator.generateIndexActionJson("2", "en-GB", new IndexActionData { ContentType = new[] { "Content", "HomePage" }, Language = new TestSupport.Language { DisplayName = "English", Name = "en-GB" }, Id = "content2", NameSearchable = "Tim Cook", Author = "manv", Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item3 = TestDataCreator.generateIndexActionJson("3", "en-US", new IndexActionData { ContentType = new[] { "Content", "HomePage" }, Language = new TestSupport.Language { DisplayName = "English", Name = "en-US" }, Id = "content3", NameSearchable = "Alan Turing", Author = "manv", Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item4 = TestDataCreator.generateIndexActionJson("4", "en", new IndexActionData { ContentType = new[] { "Content", "HomePage" }, Language = new TestSupport.Language { DisplayName = "English", Name = "en" }, Id = "content4", NameSearchable = "Home 4", Priority = 300, IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
-            SetupData<HomePage>(item1 + item2 + item3 + item4);
+            SetupData<HomePage>(item1 + item2 + item3 + item4, "t7");
         }
         [TestMethod]
         public void search_with_fields_should_result_2_items()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/OrderByTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/OrderByTests.cs
@@ -19,7 +19,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content3", NameSearchable = "Kiss", IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE, StartPublish = DateTime.Parse("2022-10-11T17:17:56Z", null, DateTimeStyles.AdjustToUniversal) });
             var item4 = TestDataCreator.generateIndexActionJson("4", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content4", NameSearchable = "Beatles", Priority = 300, IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE, StartPublish = DateTime.Parse("1967-10-11T17:17:56Z", null, DateTimeStyles.AdjustToUniversal) });
 
-            SetupData<HomePage>(item1 + item2 + item3 + item4);
+            SetupData<HomePage>(item1 + item2 + item3 + item4, "t8");
         }
         [TestMethod]
         public void orderby_on_searchable_string_should_return_correct_order()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/QueryAutocompleteOperatorTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/QueryAutocompleteOperatorTests.cs
@@ -17,7 +17,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "myid3", NameSearchable = "Not exists priority", IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item4 = TestDataCreator.generateIndexActionJson("4", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "notmyidandtheidtoolong", NameSearchable = "Home 4", Priority = 300, IsSecret = false, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<HomePage>(item1 + item2 + item3 + item4);
+            SetupData<HomePage>(item1 + item2 + item3 + item4, "t9");
         }
 		[TestMethod]
         public void autocomplete_id_contains_myid_should_result_3_phrases()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/QueryWithDateFilterOperatorTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/QueryWithDateFilterOperatorTests.cs
@@ -23,7 +23,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
                 StartPublish = DateTime.Parse("2022-11-11T05:17:56Z", null, DateTimeStyles.AdjustToUniversal), Status = TestDataCreator.STATUS_PUBLISHED,
                 RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<HomePage>(item1 + item2 + item3);
+            SetupData<HomePage>(item1 + item2 + item3, "t10");
         }
         [TestMethod]
         public void search_startpublish_Equals_datetime_should_return_1_item()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/QueryWithNumericFilterOperatorTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/QueryWithNumericFilterOperatorTests.cs
@@ -17,7 +17,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content3", NameSearchable = "Not exists priority", Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item4 = TestDataCreator.generateIndexActionJson("4", "en", new IndexActionData { ContentType = new[] { "HomePage" }, Id = "content3", NameSearchable = "Home 4", Priority = 300, Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<HomePage>(item1 + item2 + item3 + item4);
+            SetupData<HomePage>(item1 + item2 + item3 + item4, "t11");
         }
         [TestMethod]   
         public void search_priority_Equals_100_should_return_2_items()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/QueryWithStringFilterOperatorTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/QueryWithStringFilterOperatorTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
 {
     [TestClass]
-    public class Query_With_String_Filter_Operator : IntegrationFixture
+    public class QueryWithStringFilterOperatorTests : IntegrationFixture
     {
         [ClassInitialize]
         public static void ClassInitialize(TestContext testContext)
@@ -16,7 +16,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item2 = TestDataCreator.generateIndexActionJson("2", "en", new IndexActionData { ContentType = new[] { "Content" }, Id = "content2", NameSearchable = "Steve Howey", Author = "Steve Howey", Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "Content" }, Id = "content3", NameSearchable = "Alan Turing", Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<Content>(item1 + item2 + item3);
+            SetupData<Content>(item1 + item2 + item3, "t12");
 
         }
 

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/SimpleQueryTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/SimpleQueryTests.cs
@@ -17,7 +17,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
             var item2 = TestDataCreator.generateIndexActionJson("2", "en", new IndexActionData { ContentType = new[] { "Content" }, Id = "content2", NameSearchable = "Tim Cook", Author = "manv", Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
             var item3 = TestDataCreator.generateIndexActionJson("3", "en", new IndexActionData { ContentType = new[] { "Content" }, Id = "content3", NameSearchable = "Alan Turing", Author = "manv", Status = TestDataCreator.STATUS_PUBLISHED, RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE });
 
-            SetupData<Content>(item1 + item2 + item3);
+            SetupData<Content>(item1 + item2 + item3, "t13");
         }
         [TestMethod]
         public void search_with_fields_should_result_3_items()

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/SubTypeQueryTests.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/QueryTests/SubTypeQueryTests.cs
@@ -48,7 +48,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.QueryTests
                 RolesWithReadAccess = TestDataCreator.ROLES_EVERYONE
             });
 
-            SetupData<HomePage>(item1 + item2 + item3);
+            SetupData<HomePage>(item1 + item2 + item3, "t14");
         }
 
         [TestCategory("Subtype test")]

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/TestSupport/IntegrationFixture.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/TestSupport/IntegrationFixture.cs
@@ -201,15 +201,15 @@ namespace EPiServer.ContentGraph.IntegrationTests.TestSupport
                 return false;
             }
         }
-        protected static void SetupData<T>(string indexingData)
+        protected static void SetupData<T>(string indexingData, string testId)
         {
             string path = $@"{WorkingDirectory}\TestingData\SimpleTypeMapping.json";
             using (StreamReader mappingReader = new StreamReader(path))
             {
                 string mapping = mappingReader.ReadToEnd();
-                ClearData<T>();
-                PushMapping(mapping);
-                BulkIndexing<T>(indexingData);
+                ClearData<T>(testId);
+                PushMapping(mapping, testId);
+                BulkIndexing<T>(indexingData, testId);
             }
         }
     }


### PR DESCRIPTION
# This PR will fix the flaky tests by
- Run integration tests with individual ID so they don't interfere with each other
- Make tests more informative when they fail

# Pros and cons of this change
I've noticed that the tests typically takes 10 minutes to run with this 3864faafef3f71cdc844b804502d470beae48a74 change, instead of the 5 minutes before. However, they will never fail due to being flaky. I have no idea why using individual ID per test 3864faafef3f71cdc844b804502d470beae48a74 increased the time.