### PR TITLE
Adding facet selector for collections

### DIFF
--- a/APIs/src/EpiServer.ContentGraph/Api/Querying/TypeQueryBuilder.cs
+++ b/APIs/src/EpiServer.ContentGraph/Api/Querying/TypeQueryBuilder.cs
@@ -178,6 +178,85 @@ namespace EPiServer.ContentGraph.Api.Querying
                 $"{graphObject.Facets} {facet}";
             return this;
         }
+        /// <summary>
+        /// Get facet by field in a nested object
+        /// </summary>
+        /// <typeparam name="TField"></typeparam>
+        /// <param name="fieldSelector"></param>
+        /// <param name="propertySelector"></param>
+        /// <returns></returns>
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, string>> propertySelector)
+        {
+            fieldSelector.ValidateNotNullArgument("fieldSelector");
+            propertySelector.ValidateNotNullArgument("propertySelector");
+        
+            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+            return this;
+        }
+        
+        /// <summary>
+        /// Get facet by field in a nested object
+        /// </summary>
+        /// <typeparam name="TField"></typeparam>
+        /// <param name="fieldSelector"></param>
+        /// <param name="propertySelector"></param>
+        /// <returns></returns>
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, bool>> propertySelector)
+        {
+            fieldSelector.ValidateNotNullArgument("fieldSelector");
+            propertySelector.ValidateNotNullArgument("propertySelector");
+        
+            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+            return this;
+        }
+        
+        /// <summary>
+        /// Get facet by field in a nested object
+        /// </summary>
+        /// <typeparam name="TField"></typeparam>
+        /// <param name="fieldSelector"></param>
+        /// <param name="propertySelector"></param>
+        /// <returns></returns>
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, int>> propertySelector)
+        {
+            fieldSelector.ValidateNotNullArgument("fieldSelector");
+            propertySelector.ValidateNotNullArgument("propertySelector");
+        
+            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+            return this;
+        }
+        
+        /// <summary>
+        /// Get facet by field in a nested object
+        /// </summary>
+        /// <typeparam name="TField"></typeparam>
+        /// <param name="fieldSelector"></param>
+        /// <param name="propertySelector"></param>
+        /// <returns></returns>
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, DateTime>> propertySelector)
+        {
+            fieldSelector.ValidateNotNullArgument("fieldSelector");
+            propertySelector.ValidateNotNullArgument("propertySelector");
+        
+            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+            return this;
+        }
+        
+        /// <summary>
+        /// Get facet by field in a nested object
+        /// </summary>
+        /// <typeparam name="TField"></typeparam>
+        /// <param name="fieldSelector"></param>
+        /// <param name="propertySelector"></param>
+        /// <returns></returns>
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, object>> propertySelector)
+        {
+            fieldSelector.ValidateNotNullArgument("fieldSelector");
+            propertySelector.ValidateNotNullArgument("propertySelector");
+        
+            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+            return this;
+        }
         public TypeQueryBuilder<T> Total(bool? isAll = null)
         {
             if (!isAll.HasValue)

--- a/APIs/src/EpiServer.ContentGraph/Api/Querying/TypeQueryBuilder.cs
+++ b/APIs/src/EpiServer.ContentGraph/Api/Querying/TypeQueryBuilder.cs
@@ -9,18 +9,22 @@ using EPiServer.ContentGraph.Api.Facets;
 using EPiServer.ServiceLocation;
 using EPiServer.ContentGraph.ExpressionHelper;
 using System.Text.RegularExpressions;
+using EPiServer.ContentGraph.Extensions;
 
 namespace EPiServer.ContentGraph.Api.Querying
 {
     public partial class TypeQueryBuilder<T> : TypeQueryBuilder
     {
         private static IEnumerable<IFilterForVisitor>? _filters;
+
         public TypeQueryBuilder(GraphQLRequest request) : base(request)
         {
         }
+
         public TypeQueryBuilder() : base()
         {
         }
+
         public override GraphQLRequest GetQuery()
         {
             ToQuery();
@@ -28,32 +32,38 @@ namespace EPiServer.ContentGraph.Api.Querying
         }
 
         #region Queries
+
         public TypeQueryBuilder<T> Link<TLink>(TypeQueryBuilder<TLink> link)
         {
             base.Link(link);
             return this;
         }
+
         [Obsolete("Use Link method instead")]
         public TypeQueryBuilder<T> Children<TChildren>(TypeQueryBuilder<TChildren> children)
         {
             base.Children(children);
             return this;
         }
+
         public override TypeQueryBuilder<T> Fragments(params FragmentBuilder[] fragments)
         {
             base.Fragments(fragments);
             return this;
         }
+
         protected override TypeQueryBuilder<T> Fragment(FragmentBuilder fragment)
         {
             base.Fragment(fragment);
             return this;
         }
+
         public override TypeQueryBuilder<T> Field(string propertyName)
         {
             base.Field(propertyName);
             return this;
         }
+
         public TypeQueryBuilder<T> Field(Expression<Func<T, object>> fieldSelector)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -61,6 +71,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             Field(propertyName);
             return this;
         }
+
         public TypeQueryBuilder<T> Fields(params Expression<Func<T, object>>[] fieldSelectors)
         {
             fieldSelectors.ValidateNotNullArgument("fieldSelectors");
@@ -70,12 +81,11 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
-        /// <summary>
-        /// Select fields in a subtype. The response of your query may need to convert data type. If then consider to use GetContent<TOriginal,TExpectedType> method.
-        /// </summary>
-        /// <typeparam name="TSub">Subtype must be inherited from type <typeparamref name="T"/></typeparam>
-        /// <param name="propertyName"></param>
-        /// <returns></returns>
+
+        /// <summary> Select fields in a subtype. The response of your query may need to convert
+        /// data type. If then consider to use GetContent<TOriginal,TExpectedType> method.
+        /// </summary> <typeparam name="TSub">Subtype must be inherited from type <typeparamref
+        /// name="T"/></typeparam> <param name="propertyName"></param> <returns></returns>
         public TypeQueryBuilder<T> AsType<TSub>(string propertyName) where TSub : T
         {
             string subTypeName = typeof(TSub).Name;
@@ -84,12 +94,11 @@ namespace EPiServer.ContentGraph.Api.Querying
                 $"{graphObject.SelectItems} ... on {subTypeName}{{{ConvertNestedFieldToString.ConvertNestedFieldForQuery(propertyName)}}}";
             return this;
         }
-        /// <summary>
-        /// Select fields in a subtype. The response of your query may need to convert data type. If then consider to use GetContent<TOriginal,TExpectedType> method.
-        /// </summary>
-        /// <typeparam name="TSub">Subtype must be inherited from type <typeparamref name="T"/></typeparam>
-        /// <param name="fieldSelector"></param>
-        /// <returns></returns>
+
+        /// <summary> Select fields in a subtype. The response of your query may need to convert
+        /// data type. If then consider to use GetContent<TOriginal,TExpectedType> method.
+        /// </summary> <typeparam name="TSub">Subtype must be inherited from type <typeparamref
+        /// name="T"/></typeparam> <param name="fieldSelector"></param> <returns></returns>
         public TypeQueryBuilder<T> AsType<TSub>(params Expression<Func<TSub, object>>[] fieldSelectors) where TSub : T
         {
             fieldSelectors.ValidateNotNullArgument("fieldSelectors");
@@ -101,7 +110,6 @@ namespace EPiServer.ContentGraph.Api.Querying
                     propertyName += " ";
                 }
                 propertyName += ConvertNestedFieldToString.ConvertNestedFieldForQuery(fieldSelector.GetFieldPath());
-
             }
             string subTypeName = typeof(TSub).Name;
             graphObject.SelectItems = graphObject.SelectItems.IsNullOrEmpty() ?
@@ -109,12 +117,11 @@ namespace EPiServer.ContentGraph.Api.Querying
                 $"{graphObject.SelectItems} ... on {subTypeName}{{{propertyName}}}";
             return this;
         }
-        /// <summary>
-        /// Select fields in a subtype. The response of your query may need to convert data type. If then consider to use GetContent<TOriginal,TExpectedType> method.
-        /// </summary>
-        /// <typeparam name="TSub">Subtype must be inherited from type <typeparamref name="T"/></typeparam>
-        /// <param name="propertyName"></param>
-        /// <returns></returns>
+
+        /// <summary> Select fields in a subtype. The response of your query may need to convert
+        /// data type. If then consider to use GetContent<TOriginal,TExpectedType> method.
+        /// </summary> <typeparam name="TSub">Subtype must be inherited from type <typeparamref
+        /// name="T"/></typeparam> <param name="propertyName"></param> <returns></returns>
         public TypeQueryBuilder<T> AsType<TSub>(SubTypeQueryBuilder<TSub> subTypeQuery) where TSub : T
         {
             subTypeQuery.ValidateNotNullArgument("subTypeQuery");
@@ -141,6 +148,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
+
         /// <summary>
         /// Get facet by field
         /// </summary>
@@ -152,24 +160,28 @@ namespace EPiServer.ContentGraph.Api.Querying
             Facet(fieldSelector.GetFieldPath());
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(Expression<Func<T, DateTime>> fieldSelector)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
             Facet(fieldSelector.GetFieldPath());
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(Expression<Func<T, bool>> fieldSelector)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
             Facet(fieldSelector.GetFieldPath());
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(Expression<Func<T, int>> fieldSelector)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
             Facet(fieldSelector.GetFieldPath());
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(string propertyName)
         {
             string facet = ConvertNestedFieldToString.ConvertNestedFieldForFacet(propertyName);
@@ -178,85 +190,92 @@ namespace EPiServer.ContentGraph.Api.Querying
                 $"{graphObject.Facets} {facet}";
             return this;
         }
+
         /// <summary>
         /// Get facet by field in a nested object
         /// </summary>
         /// <typeparam name="TField"></typeparam>
-        /// <param name="fieldSelector"></param>
-        /// <param name="propertySelector"></param>
+        /// <param name="fieldSelector">The object</param>
+        /// <param name="propertySelector">Inner property of the object</param>
+        /// <param name="limit">Number of facets to be returned</param>
         /// <returns></returns>
-        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, string>> propertySelector)
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, string>> propertySelector, int? limit = null)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
             propertySelector.ValidateNotNullArgument("propertySelector");
-        
-            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+
+            Facet($"{(limit.HasValue ? fieldSelector.GetFieldPath().FacetLimit(limit.Value) : fieldSelector.GetFieldPath())}.{propertySelector.GetFieldPath()}");
             return this;
         }
-        
+
         /// <summary>
         /// Get facet by field in a nested object
         /// </summary>
         /// <typeparam name="TField"></typeparam>
-        /// <param name="fieldSelector"></param>
-        /// <param name="propertySelector"></param>
+        /// <param name="fieldSelector">The object</param>
+        /// <param name="propertySelector">Inner property of the object</param>
+        /// <param name="limit">Number of facets to be returned</param>
         /// <returns></returns>
-        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, bool>> propertySelector)
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, bool>> propertySelector, int? limit = null)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
             propertySelector.ValidateNotNullArgument("propertySelector");
-        
-            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+
+            Facet($"{(limit.HasValue ? fieldSelector.GetFieldPath().FacetLimit(limit.Value) : fieldSelector.GetFieldPath())}.{propertySelector.GetFieldPath()}");
             return this;
         }
-        
+
         /// <summary>
         /// Get facet by field in a nested object
         /// </summary>
         /// <typeparam name="TField"></typeparam>
-        /// <param name="fieldSelector"></param>
-        /// <param name="propertySelector"></param>
+        /// <param name="fieldSelector">The object</param>
+        /// <param name="propertySelector">Inner property of the object</param>
+        /// <param name="limit">Number of facets to be returned</param>
         /// <returns></returns>
-        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, int>> propertySelector)
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, int>> propertySelector, int? limit = null)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
             propertySelector.ValidateNotNullArgument("propertySelector");
-        
-            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+
+            Facet($"{(limit.HasValue ? fieldSelector.GetFieldPath().FacetLimit(limit.Value) : fieldSelector.GetFieldPath())}.{propertySelector.GetFieldPath()}");
             return this;
         }
-        
+
         /// <summary>
         /// Get facet by field in a nested object
         /// </summary>
         /// <typeparam name="TField"></typeparam>
-        /// <param name="fieldSelector"></param>
-        /// <param name="propertySelector"></param>
+        /// <param name="fieldSelector">The object</param>
+        /// <param name="propertySelector">Inner property of the object</param>
+        /// <param name="limit">Number of facets to be returned</param>
         /// <returns></returns>
-        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, DateTime>> propertySelector)
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, DateTime>> propertySelector, int? limit = null)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
             propertySelector.ValidateNotNullArgument("propertySelector");
-        
-            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+
+            Facet($"{(limit.HasValue ? fieldSelector.GetFieldPath().FacetLimit(limit.Value) : fieldSelector.GetFieldPath())}.{propertySelector.GetFieldPath()}");
             return this;
         }
-        
+
         /// <summary>
         /// Get facet by field in a nested object
         /// </summary>
         /// <typeparam name="TField"></typeparam>
-        /// <param name="fieldSelector"></param>
-        /// <param name="propertySelector"></param>
+        /// <param name="fieldSelector">The object</param>
+        /// <param name="propertySelector">Inner property of the object</param>
+        /// <param name="limit">Number of facets to be returned</param>
         /// <returns></returns>
-        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, object>> propertySelector)
+        public TypeQueryBuilder<T> Facet<TField>(Expression<Func<T, IEnumerable<TField>>> fieldSelector, Expression<Func<TField, object>> propertySelector, int? limit = null)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
             propertySelector.ValidateNotNullArgument("propertySelector");
-        
-            Facet($"{fieldSelector.GetFieldPath()}.{propertySelector.GetFieldPath()}");
+
+            Facet($"{(limit.HasValue ? fieldSelector.GetFieldPath().FacetLimit(limit.Value) : fieldSelector.GetFieldPath())}.{propertySelector.GetFieldPath()}");
             return this;
         }
+
         public TypeQueryBuilder<T> Total(bool? isAll = null)
         {
             if (!isAll.HasValue)
@@ -270,6 +289,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         /// <summary>
         /// Get scroll id from search
         /// </summary>
@@ -279,14 +299,17 @@ namespace EPiServer.ContentGraph.Api.Querying
             graphObject.Cursor = "cursor";
             return this;
         }
-        #endregion
+
+        #endregion Queries
 
         #region Filters
+
         public TypeQueryBuilder<T> Skip(long skip)
         {
             graphObject.Skip = $"skip:{skip}";
             return this;
         }
+
         /// <summary>
         /// Set scroll id for search query
         /// </summary>
@@ -302,12 +325,14 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
+
         public TypeQueryBuilder<T> Ids(params string[] ids)
         {
             ids.ValidateNotNullArgument("ids");
             graphObject.Ids = $"ids:[{string.Join(',', ids.Select(id => $"\"{id}\""))}]";
             return this;
         }
+
         public TypeQueryBuilder<T> Locale(LocaleMode locale)
         {
             if (!locale.IsNull())
@@ -319,6 +344,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
+
         public TypeQueryBuilder<T> Locales(params CultureInfo[] cultures)
         {
             cultures.ValidateNotNullArgument("cultures");
@@ -326,6 +352,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             graphObject.Locale = allLocales;
             return this;
         }
+
         /// <summary>
         /// Order for a field. Add more for order many fields.
         /// </summary>
@@ -347,6 +374,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
+
         public TypeQueryBuilder<T> OrderBy(Expression<Func<T, object>> fieldSelector, OrderMode orderMode, Ranking? ranking)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -363,6 +391,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         public TypeQueryBuilder<T> OrderBy(Ranking ranking = Ranking.SEMANTIC)
         {
             if (graphObject.OrderBy.IsNullOrEmpty())
@@ -376,16 +405,19 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         public TypeQueryBuilder<T> Limit(int limit = 20)
         {
             graphObject.Limit = $"limit:{limit}";
             return this;
         }
+
         public TypeQueryBuilder<T> Search(IFilterOperator filterOperator)
         {
             Where(FIELDS.FULLTEXT, filterOperator);
             return this;
         }
+
         /// <summary>
         /// Full text search using Match operator
         /// </summary>
@@ -396,7 +428,9 @@ namespace EPiServer.ContentGraph.Api.Querying
             Where(FIELDS.FULLTEXT, new StringFilterOperators().Match(q));
             return this;
         }
+
         private Dictionary<string, string> FullTextFilters = new Dictionary<string, string>();
+
         private string MergeFilters(string exsting, string additional)
         {
             Regex reg = new Regex(@"\{.*\}");
@@ -404,10 +438,11 @@ namespace EPiServer.ContentGraph.Api.Querying
             var newFilter = reg.Match(additional).Value;
             if (originalFilter != newFilter)
             {
-                return $"{originalFilter.Replace("{","").Replace("}","")},{newFilter.Replace("{", "").Replace("}", "")}";
+                return $"{originalFilter.Replace("{", "").Replace("}", "")},{newFilter.Replace("{", "").Replace("}", "")}";
             }
             return exsting;
         }
+
         public TypeQueryBuilder<T> Where(string fieldName, IFilterOperator filterOperator)
         {
             filterOperator.ValidateNotNullArgument("filterOperator");
@@ -440,6 +475,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         public TypeQueryBuilder<T> Where(Expression<Func<T, Filter>> fieldSelector)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -451,6 +487,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
+
         public TypeQueryBuilder<T> Where(Expression<Func<T, string>> fieldSelector, StringFilterOperators filterOperator)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -459,6 +496,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         public TypeQueryBuilder<T> Where(Expression<Func<T, long?>> fieldSelector, NumericFilterOperators filterOperator)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -467,6 +505,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         public TypeQueryBuilder<T> Where(Expression<Func<T, string>> fieldSelector, DateFilterOperators filterOperator)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -475,6 +514,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         public TypeQueryBuilder<T> Where(Expression<Func<T, bool>> fieldSelector, BooleanFilterOperators filterOperator)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -483,6 +523,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         public TypeQueryBuilder<T> Where(Expression<Func<T, DateTime?>> fieldSelector, DateFilterOperators filterOperator)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -491,6 +532,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         public TypeQueryBuilder<T> Where(IFilter filter)
         {
             filter.ValidateNotNullArgument("filter");
@@ -505,6 +547,7 @@ namespace EPiServer.ContentGraph.Api.Querying
 
             return this;
         }
+
         private TypeQueryBuilder<T> Facet(string propertyName, IFacetOperator facetFilter)
         {
             propertyName.ValidateNotNullArgument("propertyName");
@@ -515,6 +558,7 @@ namespace EPiServer.ContentGraph.Api.Querying
                 $"{graphObject.Facets} {facets}";
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(Expression<Func<T, object>> fieldSelector, IFacetOperator facetFilter)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -522,6 +566,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             Facet(fieldSelector.GetFieldPath(), facetFilter);
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(params Expression<Func<T, FacetFilter>>[] facetFilters)
         {
             facetFilters.ValidateNotNullArgument("facetFilters");
@@ -533,6 +578,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(IEnumerable<FacetFilter> facetFilters)
         {
             facetFilters.ValidateNotNullArgument("facetFilters");
@@ -542,6 +588,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
+
         /// <summary>
         /// Get facet with filter
         /// </summary>
@@ -555,6 +602,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             Facet(fieldSelector.GetFieldPath(), facetFilter);
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(Expression<Func<T, bool>> fieldSelector, StringFacetFilterOperators facetFilter)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -562,6 +610,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             Facet(fieldSelector.GetFieldPath(), facetFilter);
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(Expression<Func<T, object>> fieldSelector, StringFacetFilterOperators facetFilter)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -569,6 +618,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             Facet(fieldSelector.GetFieldPath(), facetFilter);
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(Expression<Func<T, int?>> fieldSelector, NumericFacetFilterOperators facetFilter)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -576,6 +626,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             Facet(fieldSelector.GetFieldPath(), facetFilter);
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(Expression<Func<T, DateTime?>> fieldSelector, DateFacetFilterOperators facetFilter)
         {
             fieldSelector.ValidateNotNullArgument("fieldSelector");
@@ -583,6 +634,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             Facet(fieldSelector.GetFieldPath(), facetFilter);
             return this;
         }
+
         public TypeQueryBuilder<T> Facet(IFacetFilter facetFilter)
         {
             facetFilter.ValidateNotNullArgument("facetFilter");
@@ -591,6 +643,7 @@ namespace EPiServer.ContentGraph.Api.Querying
                 $"{graphObject.Facets} {facetFilter.FilterClause}";
             return this;
         }
+
         public TypeQueryBuilder<T> FilterForVisitor(params IFilterForVisitor[] filterForVisitors)
         {
             if (filterForVisitors != null && filterForVisitors.Length > 0)
@@ -611,7 +664,8 @@ namespace EPiServer.ContentGraph.Api.Querying
             }
             return this;
         }
-        #endregion
+
+        #endregion Filters
 
         /// <summary>
         /// Build the query for current type
@@ -692,9 +746,9 @@ namespace EPiServer.ContentGraph.Api.Querying
         public TypeQueryBuilder(GraphQLRequest request) : base(request)
         {
         }
+
         public TypeQueryBuilder() : base()
         {
         }
-
     }
 }


### PR DESCRIPTION
Adding facets selector based on how the facets are setup.  Allows facets to be selected based on type query.Facet(x=>x.Categories, c=>c.GuidValue)