### PR TITLE
Adding alias as a field options

### DIFF
--- a/APIs/src/EpiServer.ContentGraph/Api/Querying/TypeQueryBuilder.cs
+++ b/APIs/src/EpiServer.ContentGraph/Api/Querying/TypeQueryBuilder.cs
@@ -61,6 +61,13 @@ namespace EPiServer.ContentGraph.Api.Querying
             Field(propertyName);
             return this;
         }
+        public TypeQueryBuilder<T> Field(Expression<Func<T, object>> fieldSelector, string alias)
+        {
+            fieldSelector.ValidateNotNullArgument("fieldSelector");
+            var propertyName = fieldSelector.GetFieldPath();
+            Field($"{alias}:{propertyName}");
+            return this;
+        }
         public TypeQueryBuilder<T> Fields(params Expression<Func<T, object>>[] fieldSelectors)
         {
             fieldSelectors.ValidateNotNullArgument("fieldSelectors");


### PR DESCRIPTION
Adding another method to support passing in an alias for a field.  Would like to keep it normal and minimal as possible so passing in another property is better than extension method on a string