### PR TITLE
Allow TransformAction to clone options

### DIFF
--- a/APIs/src/EpiServer.ContentGraph/Api/Querying/GraphQueryBuilder.cs
+++ b/APIs/src/EpiServer.ContentGraph/Api/Querying/GraphQueryBuilder.cs
@@ -42,6 +42,14 @@ namespace EPiServer.ContentGraph.Api.Querying
                 var httpClientFactory = ServiceLocator.Current.GetService(typeof(IHttpClientFactory)) as IHttpClientFactory;
                 if (transformAction != null)
                 {
+                    if (options.TransformActionBehaviour == TransformActionBehaviour.Clone)
+                    {
+                        var clonedOptions = (OptiGraphOptions)options.Clone();
+                        transformAction(clonedOptions);
+
+                        return new GraphQueryBuilder(clonedOptions, httpClientFactory);
+                    }
+
                     transformAction(options);
                 }
                 if (options != null)

--- a/APIs/src/EpiServer.ContentGraph/Configuration/OptiGraphOptions.cs
+++ b/APIs/src/EpiServer.ContentGraph/Configuration/OptiGraphOptions.cs
@@ -5,7 +5,7 @@ using EPiServer.ServiceLocation;
 namespace EPiServer.ContentGraph.Configuration
 {
     [Options]
-    public class OptiGraphOptions
+    public class OptiGraphOptions : ICloneable
     {
         public const string ConfigSection = "Optimizely:ContentGraph";
 
@@ -56,6 +56,13 @@ namespace EPiServer.ContentGraph.Configuration
                 }
                 return $"epi-single {SingleKey}";
             }
+        }
+
+        public TransformActionBehaviour TransformActionBehaviour {  get; set; }
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
         }
     }
 }

--- a/APIs/src/EpiServer.ContentGraph/Configuration/TransformActionBehaviour.cs
+++ b/APIs/src/EpiServer.ContentGraph/Configuration/TransformActionBehaviour.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPiServer.ContentGraph.Configuration
+{
+    /// <summary>
+    /// Configures how OptiGraphOptions should handle the output of TransformAction when creating options
+    /// </summary>
+    public enum TransformActionBehaviour
+    {
+        /// <summary>
+        /// Default, transform action changes the global options
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Clone, transform action clones the options and applies transformation only on the clone
+        /// </summary>
+        Clone
+    }
+}


### PR DESCRIPTION
When the client is used to query different graph
sources the transform action passed to
CreateFromConfig can be used to manipulate the
keys sent. However the changes are applied to the
global options and doesnt reset after the client
has finished its query.

By introducing a behaviour it is possible to
dictatate if the developer wants to be able to
apply the transformation on a clone of the
options.

The default behaviour is that the current behavior where the options are global.