### PR TITLE
Handle invalid token

### DIFF
--- a/APIs/src/EpiServer.ContentGraph/Api/Querying/GraphQueryBuilder.cs
+++ b/APIs/src/EpiServer.ContentGraph/Api/Querying/GraphQueryBuilder.cs
@@ -12,6 +12,7 @@ using EPiServer.ServiceLocation;
 using EPiServer.ContentGraph.Helpers.Text;
 using EPiServer.ContentGraph.Helpers;
 using EPiServer.ContentGraph.Tracing;
+using System.Net;
 
 namespace EPiServer.ContentGraph.Api.Querying
 {
@@ -228,6 +229,11 @@ namespace EPiServer.ContentGraph.Api.Querying
                 }
                 catch (HttpRequestException e)
                 {
+                    if (e.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        throw e;
+                    }
+
                     try
                     {
                         return JsonConvert.DeserializeObject<ContentGraphResult>(e.Message);


### PR DESCRIPTION
If the token is invalid and the user cannot be authorized then swallong the unauthorized exception will lead to a null reference error. By exposing the HttpRequestException the application will know that the user was unauthorized.

Fixes: CMS-40534