### PR TITLE
Release/1.4.2 - Only taking the first base class

### DIFF
--- a/APIs/src/CGTypeSync/Program.cs
+++ b/APIs/src/CGTypeSync/Program.cs
@@ -153,7 +153,8 @@ namespace Optimizely.Graph.Client.Tools
 
                 if (parentTypes != null && parentTypes.Count() > 0)
                 {
-                    inheritedFromType = string.Join(',', parentTypes.Select(type=> type.ToString()));
+                    //inheritedFromType = string.Join(',', parentTypes.Select(type=> type.ToString()));
+                    inheritedFromType = parentTypes.Select(type => type.ToString()).First();
                     inheritedFromType = $":{inheritedFromType}";
                 }
                 sb.AppendLine($"    public partial class {propertyTypeName}{inheritedFromType}");

--- a/msbuild/version.props
+++ b/msbuild/version.props
@@ -1,7 +1,7 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.4.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Only takes the first base class when creating the ogschema model