### PR TITLE
Make OptiGraphOptions to be scoped lifecircle

### DIFF
--- a/APIs/src/EpiServer.ContentGraph/Api/FIELDS.cs
+++ b/APIs/src/EpiServer.ContentGraph/Api/FIELDS.cs
@@ -10,5 +10,6 @@ namespace EPiServer.ContentGraph.Api
         public const string SCORE = "_score";
         public const string TYPE_NAME = "__typename";
         public const string FULLTEXT = "_fulltext";
+        public const string TRACK = "_track";
     }
 }

--- a/APIs/src/EpiServer.ContentGraph/Api/Querying/GraphQueryBuilder.cs
+++ b/APIs/src/EpiServer.ContentGraph/Api/Querying/GraphQueryBuilder.cs
@@ -75,7 +75,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             _httpClient = _httpClientFactory.CreateClient("HttpClientWithAutoDecompression");
         }
 
-        public GraphQueryBuilder(IOptions<OptiGraphOptions> optiGraphOptions, IHttpClientFactory httpClientFactory) : 
+        public GraphQueryBuilder(IOptionsSnapshot<OptiGraphOptions> optiGraphOptions, IHttpClientFactory httpClientFactory) : 
             this(optiGraphOptions.Value, httpClientFactory)
         {
         }

--- a/APIs/src/EpiServer.ContentGraph/Api/Querying/TypeQueryBuilder.cs
+++ b/APIs/src/EpiServer.ContentGraph/Api/Querying/TypeQueryBuilder.cs
@@ -341,7 +341,7 @@ namespace EPiServer.ContentGraph.Api.Querying
             graphObject.Filter = graphObject.Filter.IsNullOrEmpty() ?
                $"track:\"{q}\"" :
                $"{graphObject.Filter}, track:\"{q}\"";
-
+            this.Field(FIELDS.TRACK);
             return this;
         }
         /// <summary>

--- a/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/TestSupport/IntegrationFixture.cs
+++ b/APIs/src/Testing/EPiServer.ContentGraph.IntegrationTests/TestSupport/IntegrationFixture.cs
@@ -28,7 +28,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.TestSupport
         protected static string? WorkingDirectory;
         private static HttpClient? _httpClient;
         private static string USER_AGENT => $"Optimizely-Graph-NET-API/{typeof(IntegrationFixture).Assembly.GetName().Version}";
-        protected static IOptions<OptiGraphOptions> _configOptions;
+        protected static IOptionsSnapshot<OptiGraphOptions> _configOptions;
         protected static IHttpClientFactory _httpClientFactory;
 
         [AssemblyInitialize]
@@ -51,7 +51,7 @@ namespace EPiServer.ContentGraph.IntegrationTests.TestSupport
                 .ConfigureServices(services => ConfigureServices(services))
                 .Build();
 
-            _configOptions = testingHost.Services.GetService<IOptions<OptiGraphOptions>>();
+            _configOptions = testingHost.Services.GetService<IOptionsSnapshot<OptiGraphOptions>>();
             _httpClientFactory = testingHost.Services.GetService<IHttpClientFactory>();
             _httpClient = CreateHttpClient();
         }


### PR DESCRIPTION
OptiGraphOptions is resolved as singleton instance, in some case, developer needs to use different OptiGraphOptions instances for connecting different servers so they would update OptiGraphOptions in runtime. Since it's singleton, it could be updated by other thread/scope and make incorrect requests. This fix change the constructor of GraphQueryBuilder from IOptions<OptiGraphOptions> (singleton) to IOptionsSnapshot<OptiGraphOptions> (scoped snapshot) for supporting developer update OptiGraphOptions in their scope request.