### PR TITLE
CG-14164 Archive the .NET client SDK repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Deprecated
+
+The Optimizely Graph Client SDKs have been deprecated. This repository is provided as read-only for reference purposes. It is no longer maintained and no longer receives any updates.
+
 # Optimizely Graph Client SDKs
 
 Welcome to the Optimizely Graph Client SDK repository! This project is dedicated to building GraphQL queries with just a few lines of C# code, aimed at supporting Optimizely's customers in constructing search queries for [Optimizely Graph](https://docs.developers.optimizely.com/platform-optimizely/v1.4.0-optimizely-graph/docs/project-graphql), similar to [Search & Navigation](https://docs.developers.optimizely.com/digital-experience-platform/v1.1.0-search-and-navigation/docs/net-client-api).


### PR DESCRIPTION
As a Graph engineer I want to archive the .NET SDK repository so that all viewers are aware of its deprecated status.

Acceptance Criteria
- A large note has been added to the top of the Read Me file indicating the repository is deprecated and no longer supported.
- The repository has been placed in an archive state that allows read-only access. The repository must not be deleted.